### PR TITLE
Simplify control flow in sample code.

### DIFF
--- a/docs/docs/examples/0001-react-js-ai-assistant/adapter.tsx
+++ b/docs/docs/examples/0001-react-js-ai-assistant/adapter.tsx
@@ -29,13 +29,11 @@ export const streamAdapter: ChatAdapter = {
         // and feed them to the observer as they are being generated
         const reader = response.body.getReader();
         const textDecoder = new TextDecoder();
-        let doneReading = false;
 
-        while (!doneReading) {
+        while (true) {
             const { value, done } = await reader.read();
             if (done) {
-                doneReading = true;
-                continue;
+                break;
             }
 
             const content = textDecoder.decode(value);

--- a/docs/docs/examples/0004-assistant-persona/_a-personas-with-url/adapter.tsx
+++ b/docs/docs/examples/0004-assistant-persona/_a-personas-with-url/adapter.tsx
@@ -26,13 +26,11 @@ export const streamAdapter: ChatAdapter = {
     // and feed them to the observer as they are being generated
     const reader = response.body.getReader();
     const textDecoder = new TextDecoder();
-    let doneReading = false;
 
-    while (!doneReading) {
+    while (true) {
       const { value, done } = await reader.read();
       if (done) {
-        doneReading = true;
-        continue;
+        break;
       }
 
       const content = textDecoder.decode(value);

--- a/docs/docs/examples/0004-assistant-persona/_b-personas-with-jsx/adapter.tsx
+++ b/docs/docs/examples/0004-assistant-persona/_b-personas-with-jsx/adapter.tsx
@@ -26,13 +26,11 @@ export const streamAdapter: ChatAdapter = {
     // and feed them to the observer as they are being generated
     const reader = response.body.getReader();
     const textDecoder = new TextDecoder();
-    let doneReading = false;
 
-    while (!doneReading) {
+    while (true) {
       const { value, done } = await reader.read();
       if (done) {
-        doneReading = true;
-        continue;
+        break;
       }
 
       const content = textDecoder.decode(value);

--- a/docs/docs/examples/0005-welcome-message/adapter.tsx
+++ b/docs/docs/examples/0005-welcome-message/adapter.tsx
@@ -26,13 +26,11 @@ export const streamAdapter: ChatAdapter = {
     // and feed them to the observer as they are being generated
     const reader = response.body.getReader();
     const textDecoder = new TextDecoder();
-    let doneReading = false;
 
-    while (!doneReading) {
+    while (true) {
       const { value, done } = await reader.read();
       if (done) {
-        doneReading = true;
-        continue;
+        break;
       }
 
       const content = textDecoder.decode(value);

--- a/docs/docs/examples/0006-custom-response-renderers/_a-streamed-data/adapter.ts
+++ b/docs/docs/examples/0006-custom-response-renderers/_a-streamed-data/adapter.ts
@@ -26,13 +26,11 @@ export const streamAdapter: ChatAdapter = {
     // and feed them to the observer as they are being generated
     const reader = response.body.getReader();
     const textDecoder = new TextDecoder();
-    let doneReading = false;
 
-    while (!doneReading) {
+    while (true) {
       const { value, done } = await reader.read();
       if (done) {
-        doneReading = true;
-        continue;
+        break;
       }
 
       const content = textDecoder.decode(value);

--- a/docs/docs/examples/0006-custom-response-renderers/_b-batched-data/adapter.ts
+++ b/docs/docs/examples/0006-custom-response-renderers/_b-batched-data/adapter.ts
@@ -26,13 +26,11 @@ export const streamAdapter: ChatAdapter = {
     // and feed them to the observer as they are being generated
     const reader = response.body.getReader();
     const textDecoder = new TextDecoder();
-    let doneReading = false;
 
-    while (!doneReading) {
+    while (true) {
       const { value, done } = await reader.read();
       if (done) {
-        doneReading = true;
-        continue;
+        break;
       }
 
       const content = textDecoder.decode(value);

--- a/docs/docs/examples/0007-conversation-history/adapter.tsx
+++ b/docs/docs/examples/0007-conversation-history/adapter.tsx
@@ -26,13 +26,11 @@ export const streamAdapter: ChatAdapter = {
     // and feed them to the observer as they are being generated
     const reader = response.body.getReader();
     const textDecoder = new TextDecoder();
-    let doneReading = false;
 
-    while (!doneReading) {
+    while (true) {
       const { value, done } = await reader.read();
       if (done) {
-        doneReading = true;
-        continue;
+        break;
       }
 
       const content = textDecoder.decode(value);

--- a/docs/docs/examples/0008-conversation-layout/adapter.tsx
+++ b/docs/docs/examples/0008-conversation-layout/adapter.tsx
@@ -26,13 +26,11 @@ export const streamAdapter: ChatAdapter = {
     // and feed them to the observer as they are being generated
     const reader = response.body.getReader();
     const textDecoder = new TextDecoder();
-    let doneReading = false;
 
-    while (!doneReading) {
+    while (true) {
       const { value, done } = await reader.read();
       if (done) {
-        doneReading = true;
-        continue;
+        break;
       }
 
       const content = textDecoder.decode(value);

--- a/docs/docs/examples/0009-markdown-streaming/adapter.tsx
+++ b/docs/docs/examples/0009-markdown-streaming/adapter.tsx
@@ -26,13 +26,11 @@ export const streamAdapter: ChatAdapter = {
     // and feed them to the observer as they are being generated
     const reader = response.body.getReader();
     const textDecoder = new TextDecoder();
-    let doneReading = false;
 
-    while (!doneReading) {
+    while (true) {
       const { value, done } = await reader.read();
       if (done) {
-        doneReading = true;
-        continue;
+        break;
       }
 
       const content = textDecoder.decode(value);

--- a/docs/docs/examples/0010-customize-theme/example-custom-button-color/adapter.tsx
+++ b/docs/docs/examples/0010-customize-theme/example-custom-button-color/adapter.tsx
@@ -26,13 +26,11 @@ export const streamAdapter: ChatAdapter = {
     // and feed them to the observer as they are being generated
     const reader = response.body.getReader();
     const textDecoder = new TextDecoder();
-    let doneReading = false;
 
-    while (!doneReading) {
+    while (true) {
       const { value, done } = await reader.read();
       if (done) {
-        doneReading = true;
-        continue;
+        break;
       }
 
       const content = textDecoder.decode(value);

--- a/docs/docs/examples/0011-syntax-highlighter/adapter.tsx
+++ b/docs/docs/examples/0011-syntax-highlighter/adapter.tsx
@@ -26,13 +26,11 @@ export const streamAdapter: ChatAdapter = {
     // and feed them to the observer as they are being generated
     const reader = response.body.getReader();
     const textDecoder = new TextDecoder();
-    let doneReading = false;
 
-    while (!doneReading) {
+    while (true) {
       const { value, done } = await reader.read();
       if (done) {
-        doneReading = true;
-        continue;
+        break;
       }
 
       const content = textDecoder.decode(value);

--- a/docs/docs/learn/_001-overview/adapter.tsx
+++ b/docs/docs/learn/_001-overview/adapter.tsx
@@ -26,13 +26,11 @@ export const streamAdapter: ChatAdapter = {
     // and feed them to the observer as they are being generated
     const reader = response.body.getReader();
     const textDecoder = new TextDecoder();
-    let doneReading = false;
 
-    while (!doneReading) {
+    while (true) {
       const { value, done } = await reader.read();
       if (done) {
-        doneReading = true;
-        continue;
+        break;
       }
 
       const content = textDecoder.decode(value);

--- a/docs/docs/learn/_005-customize-theme/example-custom-button-color/adapter.tsx
+++ b/docs/docs/learn/_005-customize-theme/example-custom-button-color/adapter.tsx
@@ -26,13 +26,11 @@ export const streamAdapter: ChatAdapter = {
     // and feed them to the observer as they are being generated
     const reader = response.body.getReader();
     const textDecoder = new TextDecoder();
-    let doneReading = false;
 
-    while (!doneReading) {
+    while (true) {
       const { value, done } = await reader.read();
       if (done) {
-        doneReading = true;
-        continue;
+        break;
       }
 
       const content = textDecoder.decode(value);

--- a/docs/src/pages/(examples)/intro/adapter.tsx
+++ b/docs/src/pages/(examples)/intro/adapter.tsx
@@ -26,13 +26,11 @@ export const streamAdapter: ChatAdapter = {
     // and feed them to the observer as they are being generated
     const reader = response.body.getReader();
     const textDecoder = new TextDecoder();
-    let doneReading = false;
 
-    while (!doneReading) {
+    while (true) {
       const { value, done } = await reader.read();
       if (done) {
-        doneReading = true;
-        continue;
+        break;
       }
 
       const content = textDecoder.decode(value);

--- a/docs/versioned_docs/version-1.0.15/examples/0001-react-js-ai-chatbot/adapter.tsx
+++ b/docs/versioned_docs/version-1.0.15/examples/0001-react-js-ai-chatbot/adapter.tsx
@@ -26,13 +26,11 @@ export const streamAdapter: Adapter = {
     // and feed them to the observer as they are being generated
     const reader = response.body.getReader();
     const textDecoder = new TextDecoder();
-    let doneReading = false;
 
-    while (!doneReading) {
+    while (true) {
       const { value, done } = await reader.read();
       if (done) {
-        doneReading = true;
-        continue;
+        break;
       }
 
       const content = textDecoder.decode(value);

--- a/docs/versioned_docs/version-1.0.15/examples/0003-bot-persona/_a-personas-with-url/adapter.tsx
+++ b/docs/versioned_docs/version-1.0.15/examples/0003-bot-persona/_a-personas-with-url/adapter.tsx
@@ -26,13 +26,11 @@ export const streamAdapter: Adapter = {
     // and feed them to the observer as they are being generated
     const reader = response.body.getReader();
     const textDecoder = new TextDecoder();
-    let doneReading = false;
 
-    while (!doneReading) {
+    while (true) {
       const { value, done } = await reader.read();
       if (done) {
-        doneReading = true;
-        continue;
+        break;
       }
 
       const content = textDecoder.decode(value);

--- a/docs/versioned_docs/version-1.0.15/examples/0003-bot-persona/_b-personas-with-jsx/adapter.tsx
+++ b/docs/versioned_docs/version-1.0.15/examples/0003-bot-persona/_b-personas-with-jsx/adapter.tsx
@@ -26,13 +26,11 @@ export const streamAdapter: Adapter = {
     // and feed them to the observer as they are being generated
     const reader = response.body.getReader();
     const textDecoder = new TextDecoder();
-    let doneReading = false;
 
-    while (!doneReading) {
+    while (true) {
       const { value, done } = await reader.read();
       if (done) {
-        doneReading = true;
-        continue;
+        break;
       }
 
       const content = textDecoder.decode(value);

--- a/docs/versioned_docs/version-1.0.15/examples/0004-conversation-history/adapter.tsx
+++ b/docs/versioned_docs/version-1.0.15/examples/0004-conversation-history/adapter.tsx
@@ -26,13 +26,11 @@ export const streamAdapter: Adapter = {
     // and feed them to the observer as they are being generated
     const reader = response.body.getReader();
     const textDecoder = new TextDecoder();
-    let doneReading = false;
 
-    while (!doneReading) {
+    while (true) {
       const { value, done } = await reader.read();
       if (done) {
-        doneReading = true;
-        continue;
+        break;
       }
 
       const content = textDecoder.decode(value);

--- a/docs/versioned_docs/version-1.0.15/examples/0005-markdown-streaming/adapter.tsx
+++ b/docs/versioned_docs/version-1.0.15/examples/0005-markdown-streaming/adapter.tsx
@@ -26,13 +26,11 @@ export const streamAdapter: Adapter = {
     // and feed them to the observer as they are being generated
     const reader = response.body.getReader();
     const textDecoder = new TextDecoder();
-    let doneReading = false;
 
-    while (!doneReading) {
+    while (true) {
       const { value, done } = await reader.read();
       if (done) {
-        doneReading = true;
-        continue;
+        break;
       }
 
       const content = textDecoder.decode(value);

--- a/docs/versioned_docs/version-1.0.15/examples/0006-syntax-highlighter/adapter.tsx
+++ b/docs/versioned_docs/version-1.0.15/examples/0006-syntax-highlighter/adapter.tsx
@@ -26,13 +26,11 @@ export const streamAdapter: Adapter = {
     // and feed them to the observer as they are being generated
     const reader = response.body.getReader();
     const textDecoder = new TextDecoder();
-    let doneReading = false;
 
-    while (!doneReading) {
+    while (true) {
       const { value, done } = await reader.read();
       if (done) {
-        doneReading = true;
-        continue;
+        break;
       }
 
       const content = textDecoder.decode(value);

--- a/docs/versioned_docs/version-1.0.15/examples/0007-customize-theme/example-custom-button-color/adapter.tsx
+++ b/docs/versioned_docs/version-1.0.15/examples/0007-customize-theme/example-custom-button-color/adapter.tsx
@@ -26,13 +26,11 @@ export const streamAdapter: Adapter = {
     // and feed them to the observer as they are being generated
     const reader = response.body.getReader();
     const textDecoder = new TextDecoder();
-    let doneReading = false;
 
-    while (!doneReading) {
+    while (true) {
       const { value, done } = await reader.read();
       if (done) {
-        doneReading = true;
-        continue;
+        break;
       }
 
       const content = textDecoder.decode(value);

--- a/docs/versioned_docs/version-1.0.15/learn/_005-customize-theme/example-custom-button-color/adapter.tsx
+++ b/docs/versioned_docs/version-1.0.15/learn/_005-customize-theme/example-custom-button-color/adapter.tsx
@@ -26,13 +26,11 @@ export const streamAdapter: ChatAdapter = {
     // and feed them to the observer as they are being generated
     const reader = response.body.getReader();
     const textDecoder = new TextDecoder();
-    let doneReading = false;
 
-    while (!doneReading) {
+    while (true) {
       const { value, done } = await reader.read();
       if (done) {
-        doneReading = true;
-        continue;
+        break;
       }
 
       const content = textDecoder.decode(value);

--- a/packages/js/langchain/src/langserve/adapter/stream.ts
+++ b/packages/js/langchain/src/langserve/adapter/stream.ts
@@ -62,7 +62,7 @@ export class LangServeStreamAdapter<AiMsg> extends LangServeAbstractAdapter<AiMs
                     const {value, done} = await reader.read();
                     if (done) {
                         doneReading = true;
-                        continue;
+                        break;
                     }
 
                     const chunk = textDecoder.decode(value);

--- a/packages/js/nlbridge/src/nlbridge/chatAdapter/stream.ts
+++ b/packages/js/nlbridge/src/nlbridge/chatAdapter/stream.ts
@@ -52,15 +52,13 @@ export class NLBridgeStreamAdapter<AiMsg> extends NLBridgeAbstractAdapter<AiMsg>
                 // and feed them to the observer as they are being generated
                 const reader = response.body.getReader();
                 const textDecoder = new TextDecoder();
-                let doneReading = false;
 
-                while (!doneReading) {
+                while (true) {
                     const {value, done} = await reader.read();
                     if (done) {
-                        doneReading = true;
-                        continue;
+                      break;
                     }
-
+              
                     try {
                         const chunk = textDecoder.decode(value);
                         observer.next(chunk);

--- a/samples/emulator/src/01-vanilla-js-with-adapters/nlBridgeCustomAdapter.ts
+++ b/samples/emulator/src/01-vanilla-js-with-adapters/nlBridgeCustomAdapter.ts
@@ -31,15 +31,13 @@ export const nlBridgeCustomStreamingAdapter: ChatAdapter<string> = {
             // and feed them to the observer as they are being generated
             const reader = response.body.getReader();
             const textDecoder = new TextDecoder();
-            let doneReading = false;
 
-            while (!doneReading) {
+            while (true) {
                 const {value, done} = await reader.read();
                 if (done) {
-                    doneReading = true;
-                    continue;
+                  break;
                 }
-
+          
                 try {
                     const chunk = textDecoder.decode(value);
                     observer.next(chunk);
@@ -85,4 +83,3 @@ export const nlBridgeCustomPromiseAdapter: ChatAdapter<string> = {
         }
     },
 };
-

--- a/samples/emulator/src/02-vanilla-js-with-events/stream.ts
+++ b/samples/emulator/src/02-vanilla-js-with-events/stream.ts
@@ -29,15 +29,13 @@ export const streamAdapter: ChatAdapter<string> = {
         // and feed them to the observer as they are being generated
         const reader = response.body.getReader();
         const textDecoder = new TextDecoder();
-        let doneReading = false;
 
-        while (!doneReading) {
+        while (true) {
             const {value, done} = await reader.read();
             if (done) {
-                doneReading = true;
-                continue;
+              break;
             }
-
+      
             const content = textDecoder.decode(value);
             if (content) {
                 observer.next(content);

--- a/samples/emulator/src/05-react-js-with-langserve/adapters/einbotStream.ts
+++ b/samples/emulator/src/05-react-js-with-langserve/adapters/einbotStream.ts
@@ -34,13 +34,11 @@ export const streamAdapter: ChatAdapter<string> = {
         // and feed them to the observer as they are being generated
         const reader = response.body.getReader();
         const textDecoder = new TextDecoder();
-        let doneReading = false;
 
-        while (!doneReading) {
+        while (true) {
             const {value, done} = await reader.read();
             if (done) {
-                doneReading = true;
-                continue;
+              break;
             }
 
             const result = textDecoder.decode(value);

--- a/samples/emulator/src/06-react-js-with-adapters/stream.ts
+++ b/samples/emulator/src/06-react-js-with-adapters/stream.ts
@@ -21,13 +21,11 @@ export const streamAdapter: ChatAdapter<string> = {
         // and feed them to the observer as they are being generated
         const reader = response.body.getReader();
         const textDecoder = new TextDecoder();
-        let doneReading = false;
 
-        while (!doneReading) {
+        while (true) {
             const {value, done} = await reader.read();
             if (done) {
-                doneReading = true;
-                continue;
+              break;
             }
 
             const content = textDecoder.decode(value);

--- a/samples/emulator/src/08-react-js-events/stream.ts
+++ b/samples/emulator/src/08-react-js-events/stream.ts
@@ -31,13 +31,11 @@ export const streamAdapter: ChatAdapter<string> = {
         // and feed them to the observer as they are being generated
         const reader = response.body.getReader();
         const textDecoder = new TextDecoder();
-        let doneReading = false;
 
-        while (!doneReading) {
+        while (true) {
             const {value, done} = await reader.read();
             if (done) {
-                doneReading = true;
-                continue;
+              break;
             }
 
             const content = textDecoder.decode(value);


### PR DESCRIPTION
eslint's default rule set includes the `no-continue` rule, which disallows any use of the `continue` keyword. This keyword is used in the project's sample code.

[no-continue rule](https://eslint.org/docs/latest/rules/no-continue)
[eslint's default rule set](https://eslint.org/docs/latest/rules/)

This PR removes the `continue` keyword, and removes the `doneReading` variable from most of the sample code, and is functionally equivalent.