### PR TITLE
Clarify the waitTimeBeforeStreamCompletion option in the docs

### DIFF
--- a/docs/docs/learn/004-adapters/004-custom-adapters/001-create-custom-adapter.mdx
+++ b/docs/docs/learn/004-adapters/004-custom-adapters/001-create-custom-adapter.mdx
@@ -90,7 +90,7 @@ export const myCustomAdapter: ChatAdapter = {
 Streaming adapters can also be used with APIs that send responses as Server-Sent Events (SSE).
 [All the examples on this website](/examples/react-js-ai-assistant) use this approach.
 
-Another potentially useful configuration is `messageOption.waitTimeBeforeStreamCompletion`,
+Another potentially useful configuration is `messageOptions.waitTimeBeforeStreamCompletion`,
 which sets the wait time in milliseconds after the last data chunk; the default value is 2000ms.
 
 ## Promise Adapters

--- a/docs/docs/learn/004-adapters/004-custom-adapters/001-create-custom-adapter.mdx
+++ b/docs/docs/learn/004-adapters/004-custom-adapters/001-create-custom-adapter.mdx
@@ -90,6 +90,9 @@ export const myCustomAdapter: ChatAdapter = {
 Streaming adapters can also be used with APIs that send responses as Server-Sent Events (SSE).
 [All the examples on this website](/examples/react-js-ai-assistant) use this approach.
 
+Another potentially useful configuration is `messageOption.waitTimeBeforeStreamCompletion`,
+which sets the wait time in milliseconds after the last data chunk; the default value is 2000ms.
+
 ## Promise Adapters
 
 Promise adapters can be used when the API sends responses in a single request (e.g. REST APIs).

--- a/docs/docs/reference/002-ui/_001-ai-chat/config/#js/messageOptions.mdx
+++ b/docs/docs/reference/002-ui/_001-ai-chat/config/#js/messageOptions.mdx
@@ -32,6 +32,6 @@ type PromptRenderer = (content: PromptRendererProps) => HTMLElement | null;
 | `showCodeBlockCopyButton` | `boolean` | `true` | If `true`, a copy button will be displayed on code blocks created withing messages. |
 | `streamingAnimationSpeed` | `number` | `10` | The interval in milliseconds between streamed AI responses. |
 | `skipStreamingAnimation` | `boolean` | `false` | If `true`, streamed AI responses will be displayed instantly without any animation. |
-| `waitTimeBeforeStreamCompletion` | `number`\|`'never'` | `2000` | Sets the wait time after the last data chunk to prevent premature streaming completion; 'never' requires manual completion. |
+| `waitTimeBeforeStreamCompletion` | `number`\|`'never'` | `2000` | Sets the wait time in milliseconds after the last data chunk to prevent premature streaming completion; 'never' requires manual completion. |
 
 * Usage:

--- a/docs/docs/reference/002-ui/_001-ai-chat/config/#js/messageOptions.mdx
+++ b/docs/docs/reference/002-ui/_001-ai-chat/config/#js/messageOptions.mdx
@@ -13,8 +13,8 @@ type MessageOptions<AiMsg = string> = {
     markdownLinkTarget?: 'blank' | 'self';
     showCodeBlockCopyButton?: boolean;
     streamingAnimationSpeed?: number;
-    waitTimeBeforeStreamCompletion?: number | 'never';
     skipStreamingAnimation?: boolean;
+    waitTimeBeforeStreamCompletion?: number | 'never';
 };
 
 // Refer to custom renderers API documentation for more information
@@ -32,5 +32,6 @@ type PromptRenderer = (content: PromptRendererProps) => HTMLElement | null;
 | `showCodeBlockCopyButton` | `boolean` | `true` | If `true`, a copy button will be displayed on code blocks created withing messages. |
 | `streamingAnimationSpeed` | `number` | `10` | The interval in milliseconds between streamed AI responses. |
 | `skipStreamingAnimation` | `boolean` | `false` | If `true`, streamed AI responses will be displayed instantly without any animation. |
+| `waitTimeBeforeStreamCompletion` | `number`\|`'never'` | `2000` | Sets the wait time after the last data chunk to prevent premature streaming completion; 'never' requires manual completion. |
 
 * Usage:

--- a/docs/docs/reference/002-ui/_001-ai-chat/config/#js/messageOptions.mdx
+++ b/docs/docs/reference/002-ui/_001-ai-chat/config/#js/messageOptions.mdx
@@ -32,6 +32,6 @@ type PromptRenderer = (content: PromptRendererProps) => HTMLElement | null;
 | `showCodeBlockCopyButton` | `boolean` | `true` | If `true`, a copy button will be displayed on code blocks created withing messages. |
 | `streamingAnimationSpeed` | `number` | `10` | The interval in milliseconds between streamed AI responses. |
 | `skipStreamingAnimation` | `boolean` | `false` | If `true`, streamed AI responses will be displayed instantly without any animation. |
-| `waitTimeBeforeStreamCompletion` | `number`\|`'never'` | `2000` | Sets the wait time in milliseconds after the last data chunk to prevent premature streaming completion; 'never' requires manual completion. |
+| `waitTimeBeforeStreamCompletion` | `number`\|`'never'` | `2000` | Sets the wait time in milliseconds after the last data chunk; 'never' requires manual completion. |
 
 * Usage:

--- a/docs/docs/reference/002-ui/_001-ai-chat/config/#react/messageOptions.mdx
+++ b/docs/docs/reference/002-ui/_001-ai-chat/config/#react/messageOptions.mdx
@@ -35,5 +35,6 @@ type PromptRenderer = FC<PromptRendererProps>;
 | `showCodeBlockCopyButton` | `boolean` | `true` | If `true`, a copy button will be displayed on code blocks created withing messages. |
 | `streamingAnimationSpeed` | `number` | `10` | The interval in milliseconds between streamed AI responses. |
 | `skipStreamingAnimation` | `boolean` | `false` | If `true`, streamed AI responses will be displayed instantly without any animation. |
+| `waitTimeBeforeStreamCompletion` | `number`\|`'never'` | `2000` | Sets the wait time after the last data chunk to prevent premature streaming completion; 'never' requires manual completion. |
 
 * Usage:

--- a/docs/docs/reference/002-ui/_001-ai-chat/config/#react/messageOptions.mdx
+++ b/docs/docs/reference/002-ui/_001-ai-chat/config/#react/messageOptions.mdx
@@ -35,6 +35,6 @@ type PromptRenderer = FC<PromptRendererProps>;
 | `showCodeBlockCopyButton` | `boolean` | `true` | If `true`, a copy button will be displayed on code blocks created withing messages. |
 | `streamingAnimationSpeed` | `number` | `10` | The interval in milliseconds between streamed AI responses. |
 | `skipStreamingAnimation` | `boolean` | `false` | If `true`, streamed AI responses will be displayed instantly without any animation. |
-| `waitTimeBeforeStreamCompletion` | `number`\|`'never'` | `2000` | Sets the wait time after the last data chunk to prevent premature streaming completion; 'never' requires manual completion. |
+| `waitTimeBeforeStreamCompletion` | `number`\|`'never'` | `2000` | Sets the wait time in milliseconds after the last data chunk to prevent premature streaming completion; 'never' requires manual completion. |
 
 * Usage:

--- a/docs/docs/reference/002-ui/_001-ai-chat/config/#react/messageOptions.mdx
+++ b/docs/docs/reference/002-ui/_001-ai-chat/config/#react/messageOptions.mdx
@@ -35,6 +35,6 @@ type PromptRenderer = FC<PromptRendererProps>;
 | `showCodeBlockCopyButton` | `boolean` | `true` | If `true`, a copy button will be displayed on code blocks created withing messages. |
 | `streamingAnimationSpeed` | `number` | `10` | The interval in milliseconds between streamed AI responses. |
 | `skipStreamingAnimation` | `boolean` | `false` | If `true`, streamed AI responses will be displayed instantly without any animation. |
-| `waitTimeBeforeStreamCompletion` | `number`\|`'never'` | `2000` | Sets the wait time in milliseconds after the last data chunk to prevent premature streaming completion; 'never' requires manual completion. |
+| `waitTimeBeforeStreamCompletion` | `number`\|`'never'` | `2000` | Sets the wait time in milliseconds after the last data chunk; 'never' requires manual completion. |
 
 * Usage:


### PR DESCRIPTION
1. Added an explanation for `waitTimeBeforeStreamCompletion` in the documentation.
2. Due to the critical importance of this option for the StreamAdapter, a note has been added in the Custom Adapters section.