### PR TITLE
chore: Update ChatItem-List.css to use 'stretch' for width

### DIFF
--- a/packages/css/themes/src/common/components/ChatItem-List.css
+++ b/packages/css/themes/src/common/components/ChatItem-List.css
@@ -8,7 +8,7 @@
         margin-bottom: var(--nlux-chItm-msg-lstLt--mrgBtm);
         margin-left: var(--nlux-chItm-msg-lstLt--mrgLft);
         margin-right: var(--nlux-chItm-msg-lstLt--mrgRgt);
-        width: fill-available;
+        width: stretch;
         width: -webkit-fill-available;
         width: -moz-available;
 


### PR DESCRIPTION
It appears that the new CSS standard has updated the property values.

## Reference:
https://developer.mozilla.org/en-US/docs/Web/CSS/width
https://caniuse.com/?search=width%3A%20stretch

```
index.js:489 [webpack-dev-server] WARNING
  ⚠ Warning
  │ 
  │ (88:349) autoprefixer: Replace fill-available to stretch, because spec had been changed
  │ (from: /home/www/xxxx/node_modules/.pnpm/@ice+bundles@0.2.6_@swc+helpers@0.5.1/node_modules/@ice/bundles/compiled/postcss-loader/index.js??ruleSet[1].rules[10].use[0])
```
