### PR TITLE
Streaming in Getting Started doc for Next.js + Vercel AI

### DIFF
--- a/docs/docs/learn/002-get-started/001-vercel-ai.mdx
+++ b/docs/docs/learn/002-get-started/001-vercel-ai.mdx
@@ -230,12 +230,7 @@ export default function Chat() {
     return (
         <main className="flex min-h-screen flex-col items-center justify-between p-24">
             <div className="z-10 w-full max-w-3xl items-center justify-between font-mono text-sm lg:flex">
-                <AiChat
-                
-                messageOptions={
-                  {streamingAnimationSpeed: 5}
-                }
-                className='bg-green-500 ' adapter={chatAdapter}/>
+                <AiChat adapter={chatAdapter}/>
             </div>
         </main>
     );

--- a/docs/docs/learn/002-get-started/001-vercel-ai.mdx
+++ b/docs/docs/learn/002-get-started/001-vercel-ai.mdx
@@ -218,7 +218,6 @@ export default function Chat() {
             }
       
             const content = textDecoder.decode(value);
-            console.log(content, value)
             if (content) {
               observer.next(content);
             }

--- a/docs/docs/learn/002-get-started/001-vercel-ai.mdx
+++ b/docs/docs/learn/002-get-started/001-vercel-ai.mdx
@@ -249,7 +249,7 @@ Let's take a look at what is happening in this code:
     This tells the Next.js framework that **this file is intended to run on the client-side**.
 1. We import `AiChat` from `@nlux/react` and the default theme `@nlux/themes/nova.css`.
 2. We define a `chatAdapter` object that implements the interface `ChatAdapter`.<br />
-    It contains on method `batchText` that handles chat responses generated in a single batch.
+    It contains on method `streamText` that handles chat responses streaming.
 3. We render the `<AiChat />` component with the `chatAdapter` object.
 
 ---

--- a/docs/docs/learn/002-get-started/001-vercel-ai.mdx
+++ b/docs/docs/learn/002-get-started/001-vercel-ai.mdx
@@ -147,8 +147,7 @@ Then add the following code:
 
 ```tsx
 import { openai } from '@ai-sdk/openai';
-import { generateText } from 'ai';
-import {NextResponse} from 'next/server';
+import { streamText } from 'ai';
 
 // Allow streaming responses up to 30 seconds
 export const maxDuration = 30;
@@ -156,15 +155,19 @@ export const maxDuration = 30;
 export async function POST(req: Request) {
     const { prompt } = await req.json();
 
-    const result = await generateText({
+    const result = await streamText({
         model: openai('gpt-4-turbo'),
         messages: [{
             role: 'system',
             content: prompt,
-        }]
+        }],
+        async onFinish({ text, toolCalls, toolResults, usage, finishReason }) {
+            // implement your own logic here, e.g. for storing messages
+            // or recording token usage
+        },
     });
 
-    return NextResponse.json({ reply: result.responseMessages[0].content[0].text });
+    return result.toTextStreamResponse();
 }
 ```
 
@@ -182,24 +185,58 @@ and provide a user message input:
 
 ```tsx
 'use client';
-import {AiChat, ChatAdapter} from '@nlux/react';
+import {AiChat, ChatAdapter, StreamingAdapterObserver} from '@nlux/react';
 import '@nlux/themes/nova.css';
 
 export default function Chat() {
-    const chatAdapter: ChatAdapter = { batchText: async (prompt: string) => {
+    const chatAdapter: ChatAdapter = { 
+      
+      streamText: async (prompt: string, observer: StreamingAdapterObserver) => {
         const response = await fetch('/api/chat', {
             method: 'POST',
             body: JSON.stringify({prompt: prompt}),
             headers: {'Content-Type': 'application/json'},
         });
-        const {reply} = await response.json();
-        return reply;
-    }};
+        if (response.status !== 200) {
+            observer.error(new Error('Failed to connect to the server'));
+            return;
+          }
+      
+          if (!response.body) {
+            return;
+          }
+      
+          // Read a stream of server-sent events
+          // and feed them to the observer as they are being generated
+          const reader = response.body.getReader();
+          const textDecoder = new TextDecoder();
+      
+          while (true) {
+            const { value, done } = await reader.read();
+            if (done) {
+              break;
+            }
+      
+            const content = textDecoder.decode(value);
+            console.log(content, value)
+            if (content) {
+              observer.next(content);
+            }
+          }
+      
+          observer.complete();
+        }
+    }
 
     return (
         <main className="flex min-h-screen flex-col items-center justify-between p-24">
             <div className="z-10 w-full max-w-3xl items-center justify-between font-mono text-sm lg:flex">
-                <AiChat adapter={chatAdapter}/>
+                <AiChat
+                
+                messageOptions={
+                  {streamingAnimationSpeed: 5}
+                }
+                className='bg-green-500 ' adapter={chatAdapter}/>
             </div>
         </main>
     );


### PR DESCRIPTION
Changes to the getting started doc for Next.js + Vercel IA to do text streaming instead of batch.


For reviewers:
- Is there an example that I can apply this to as well? None of them use Vercel AI.
- Kept the `onFinish` empty function just like in Vercel IA sample. I don't have a strong opinion about keeping/removing that piece.
- Is there a way to simplify the adapter? 