### PR TITLE
A11y improvements

### DIFF
--- a/packages/react/core/src/exports/AiChat.tsx
+++ b/packages/react/core/src/exports/AiChat.tsx
@@ -212,7 +212,7 @@ export const AiChat: <AiMsg>(
                             userDefinedGreeting={uiOverrides.Greeting}
                         />
                     </div>
-                    <div className="nlux-conversation-container" ref={conversationContainerRef}>
+                    <div className="nlux-conversation-container" ref={conversationContainerRef} aria-label="Chat conversation" role="log">
                         <ForwardConversationComp
                             ref={conversationRef}
                             segments={segments}

--- a/packages/react/core/src/sections/Composer/ComposerComp.tsx
+++ b/packages/react/core/src/sections/Composer/ComposerComp.tsx
@@ -78,12 +78,14 @@ export const ComposerComp = (props: ComposerProps) => {
                 value={props.prompt}
                 onChange={handleChange}
                 onKeyDown={handleKeyDown}
+                aria-label={props.placeholder}
             />
             {!showCancelButton && (
                 <button
                     tabIndex={0}
                     disabled={disableButton}
                     onClick={() => props.onSubmit()}
+                    aria-label="Send"
                 >
                     {showSendIcon && <SendIconComp/>}
                     {!showSendIcon && props.Loader}
@@ -93,6 +95,7 @@ export const ComposerComp = (props: ComposerProps) => {
                 <button
                     tabIndex={0}
                     onClick={props.onCancel}
+                    aria-label="Cancel"
                 >
                     <CancelIconComp/>
                 </button>


### PR DESCRIPTION
Some accessibility improvements to the interface. 

I kept it simple with explicit strings, but this probably needs to have its own property configuration. 
Would that be done as its own type structure or should they be added to their respective option types? 
 

- Adds [role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/log_role) to the chat area for screen reader updates
- Adds [Aria labels](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label) to forms and buttons